### PR TITLE
DYN-9999 : dna filtering improvements

### DIFF
--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml
@@ -172,7 +172,7 @@
                                     CaretBrush="{Binding Foreground, RelativeSource={RelativeSource AncestorType=ComboBox}}"
                                     FontSize="14">
                                     <TextBox.Text>
-                                        <Binding Path="SearchInput" Mode="OneWayToSource" UpdateSourceTrigger="PropertyChanged" />
+                                        <Binding Path="SearchInput" Mode="TwoWay" UpdateSourceTrigger="PropertyChanged" />
                                     </TextBox.Text>
                                 </TextBox>
                             </ComboBox.Tag>

--- a/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
+++ b/src/NodeAutoCompleteViewExtension/Views/NodeAutoCompleteBarView.xaml.cs
@@ -75,7 +75,7 @@ namespace Dynamo.NodeAutoComplete.Views
 
         private void MoveIndex(int step)
         {
-            ViewModel.SelectedIndex = Math.Min(ViewModel.DropdownResults.Count() - 1, Math.Max(0, ViewModel.SelectedIndex + step));
+            ViewModel.SelectedIndex = Math.Min(ViewModel.FilteredView.Cast<object>().Count() - 1, Math.Max(0, ViewModel.SelectedIndex + step));
         }
 
         private void PrevButton_OnClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
### Purpose
Improve the dna to account properly only for the items that pass the search filter.
One question here is if we want to preserve the filter once the dropdown is closed and clear it only when we close the dna bar ( this is the current behavior in this PR ).

### Declarations

Check these if you believe they are true

- [ ] Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ] This PR modifies some build requirements and the readme is updated
- [ ] This PR contains no files larger than 50 MB
- [ ] This PR introduces new feature code involve network connecting and is tested with no-network mode.


### Reviewers
